### PR TITLE
Fix manual payment link

### DIFF
--- a/app/admin/applications.rb
+++ b/app/admin/applications.rb
@@ -81,14 +81,14 @@ ActiveAdmin.register Application do
     total_cost = cost_lodging + cost_partner
     balance_due = total_cost - ttl_paid
     panel "Payment Activity -- [Balance Due: #{number_to_currency(balance_due)} Total Cost: #{number_to_currency(total_cost)}]" do
-      table_for application.user.payments.where(conf_year: application.conf_year) do #application.user.payments.current_conference_payments
+      table_for application.user.payments.where(conf_year: application.conf_year) do
         column(:id) { |aid| link_to(aid.id, admin_payment_path(aid.id)) }
         column(:account_type) { |atype| atype.account_type.titleize }
         column(:transaction_type)
         column(:transaction_date) {|td| Date.parse(td.transaction_date) }
         column(:total_amount) { |ta|  number_to_currency(ta.total_amount.to_f / 100) }
       end
-      text_node link_to("[Add Manual Payment]", new_admin_payment_path(:user_id => application))
+      text_node link_to("[Add Manual Payment]", new_admin_payment_path(user_id: application.user_id))
     end
 
 

--- a/app/admin/applications.rb
+++ b/app/admin/applications.rb
@@ -18,6 +18,15 @@ ActiveAdmin.register Application do
   end
 
   filter :user_id, label: "User", as: :select, collection: -> { Application.all.map { |app| [app.display_name, app.user_id]}.uniq.sort}
+  filter :user_email, as: :select,
+    collection: -> { User.order(:email).pluck(:email) },
+    label: "User Email"
+  filter :last_name, as: :select,
+    collection: -> { Application.order(:last_name).distinct.pluck(:last_name) },
+    label: "Last Name"
+  filter :first_name, as: :select,
+    collection: -> { Application.order(:first_name).distinct.pluck(:first_name) },
+    label: "First Name"
   filter :offer_status, as: :select
   filter :result_email_sent, as: :select
   filter :workshop_selection1, label: "workshop_selection1", as: :select, collection: -> { Workshop.all.map { |mapp| [mapp.instructor, mapp.instructor]}.sort }

--- a/app/admin/applications.rb
+++ b/app/admin/applications.rb
@@ -18,13 +18,13 @@ ActiveAdmin.register Application do
   end
 
   filter :user_email, as: :select,
-    collection: -> { User.order(:email).pluck(:email) },
+    collection: -> { User.joins(:payments).distinct.order(:email).pluck(:email) },
     label: "User Email"
   filter :last_name, as: :select,
-    collection: -> { Application.order(:last_name).distinct.pluck(:last_name) },
+    collection: -> { Application.joins(user: :payments).distinct.order(:last_name).pluck(:last_name) },
     label: "Last Name"
   filter :first_name, as: :select,
-    collection: -> { Application.order(:first_name).distinct.pluck(:first_name) },
+    collection: -> { Application.joins(user: :payments).distinct.order(:first_name).pluck(:first_name) },
     label: "First Name"
   filter :offer_status, as: :select
   filter :result_email_sent, as: :select

--- a/app/admin/applications.rb
+++ b/app/admin/applications.rb
@@ -17,7 +17,6 @@ ActiveAdmin.register Application do
     button_to "Send Offer", send_offer_path(application) if application.offer_status == "not_offered"
   end
 
-  filter :user_id, label: "User", as: :select, collection: -> { Application.all.map { |app| [app.display_name, app.user_id]}.uniq.sort}
   filter :user_email, as: :select,
     collection: -> { User.order(:email).pluck(:email) },
     label: "User Email"

--- a/app/admin/payments.rb
+++ b/app/admin/payments.rb
@@ -5,34 +5,15 @@ ActiveAdmin.register Payment do
   end
   menu parent: "User Mangement", priority: 2
 
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
   permit_params :transaction_type, :transaction_status, :transaction_id, :total_amount, :transaction_date, :account_type, :result_code, :result_message, :user_account, :payer_identity, :timestamp, :transaction_hash, :user_id, :conf_year
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:transaction_type, :transaction_status, :transaction_id, :total_amount, :transaction_date, :account_type, :result_code, :result_message, :user_account, :payer_identity, :timestamp, :transaction_hash, :user_id]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
-  
-  # filter :user, as: :select, collection: -> { User.all.order(:email) }
-  # filter user.current_application, label: "Last Name (Starts with)"
-  # filter :application_first_name_start, label: "First Name (Starts with)"
 
   scope :current_conference_payments
   scope :all
 
   filter :user_id, as: :select,
-    # collection: -> { User.all.order(:email) },
     collection: -> { Application.all.order(:last_name).map { |app| [app.display_name, app.user_id] } },
     label: "Name"
   filter :conf_year, as: :select
-
 
   index do
     selectable_column
@@ -47,23 +28,17 @@ ActiveAdmin.register Payment do
       number_to_currency(amount.total_amount.to_f / 100)
     end
     column :transaction_status
-    # column :transaction_id
-
     column :transaction_date
     column :account_type
     column :result_code
     column :result_message
-    # column :user_account
-    # column :payer_identity
-    # column :timestamp
-    # column :transaction_hash
     column :created_at
     column :updated_at
   end
 
   show do
     attributes_table do
-      row :user do |user| 
+      row :user do |user|
         if (app = payment.user.applications.find_by(conf_year: ApplicationSetting.get_current_app_year))
           link_to(app.display_name, admin_application_path(app))
         else
@@ -100,7 +75,7 @@ ActiveAdmin.register Payment do
         li "<strong>User: #{User.find(params[:user_id]).display_name}</strong>".html_safe
         f.input :user_id, input_html: {value: params[:user_id]}, as: :hidden
       else
-        f.input :user, as: :select, :collection => User.all.map { |u| ["#{u.email}", u.id] }.sort  # Application.active_conference_applications.map { |a| ["#{a.display_name}", a.user_id] }.sort
+        f.input :user, as: :select, :collection => User.all.map { |u| ["#{u.email}", u.id] }.sort
       end
       li "Conf Year #{f.object.conf_year}" unless f.object.new_record?
       f.input :conf_year, input_html: {value: ApplicationSetting.get_current_app_year} unless f.object.persisted?
@@ -112,7 +87,7 @@ ActiveAdmin.register Payment do
       f.input :account_type, collection: ['scholarship', 'special', 'other']
       f.input :result_code, as: :hidden, :input_html => { value: "Manually Entered" } # 'Manually Entered'
       f.input :result_message, as: :hidden, :input_html => { value: "This was manually entered by #{current_admin_user.email}" }
-      f.input :timestamp, as: :hidden, :input_html => { value: DateTime.now.strftime("%Q").to_i } # DateTime.now.strftime("%Q").to_i
+      f.input :timestamp, as: :hidden, :input_html => { value: DateTime.now.strftime("%Q").to_i }
     end
     f.actions
   end

--- a/app/admin/payments.rb
+++ b/app/admin/payments.rb
@@ -10,10 +10,21 @@ ActiveAdmin.register Payment do
   scope :current_conference_payments
   scope :all
 
-  filter :user_id, as: :select,
-    collection: -> { Application.all.order(:last_name).map { |app| [app.display_name, app.user_id] } },
-    label: "Name"
-  filter :conf_year, as: :select
+  # filter :user_id, as: :select,
+  #   collection: -> { Application.all.order(:last_name).map { |app| [app.display_name, app.user_id] } },
+  #   label: "Name"
+  filter :payer_identity, as: :select,
+    collection: -> { Payment.order(:payer_identity).distinct.pluck(:payer_identity) },
+    label: "User Email"
+  filter :user_applications_last_name, as: :select,
+    collection: -> { Application.joins(user: :payments).distinct.order(:last_name).pluck(:last_name) },
+    label: "Last Name"
+  filter :user_applications_first_name, as: :select,
+    collection: -> { Application.joins(user: :payments).distinct.order(:first_name).pluck(:first_name) },
+    label: "First Name"
+  filter :payments_conf_year, as: :select,
+    collection: -> { Payment.order(:conf_year).distinct.pluck(:conf_year) },
+    label: "Payment Conf Year"
 
   index do
     selectable_column

--- a/app/admin/payments.rb
+++ b/app/admin/payments.rb
@@ -10,9 +10,6 @@ ActiveAdmin.register Payment do
   scope :current_conference_payments
   scope :all
 
-  # filter :user_id, as: :select,
-  #   collection: -> { Application.all.order(:last_name).map { |app| [app.display_name, app.user_id] } },
-  #   label: "Name"
   filter :payer_identity, as: :select,
     collection: -> { Payment.order(:payer_identity).distinct.pluck(:payer_identity) },
     label: "User Email"

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -34,7 +34,13 @@ class Payment < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["account_type", "conf_year", "created_at", "id", "id_value", "payer_identity", "result_code", "result_message", "timestamp", "total_amount", "transaction_date", "transaction_hash", "transaction_id", "transaction_status", "transaction_type", "updated_at", "user_account", "user_id"]
+    ["account_type", "conf_year", "created_at", "id", "id_value", "payer_identity", "payments_conf_year", "result_code", "result_message", "timestamp", "total_amount", "transaction_date", "transaction_hash", "transaction_id", "transaction_status", "transaction_type", "updated_at", "user_account", "user_id"]
+  end
+
+  # Disambiguate conf_year when joining associated tables in Ransack searches.
+  # This forces the filter to reference the payments table explicitly.
+  ransacker :payments_conf_year do |parent|
+    parent.table[:conf_year]
   end
 
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Payment, type: :model do
       it 'returns the correct attributes' do
         expected_attributes = [
           "account_type", "conf_year", "created_at", "id", "id_value",
-          "payer_identity", "result_code", "result_message", "timestamp",
+          "payer_identity", "payments_conf_year", "result_code", "result_message", "timestamp",
           "total_amount", "transaction_date", "transaction_hash",
           "transaction_id", "transaction_status", "transaction_type",
           "updated_at", "user_account", "user_id"


### PR DESCRIPTION
This pull request updates the admin filters and search capabilities for applications and payments to make it easier to filter by user details and payment year, especially when dealing with joined tables. It introduces new filters for user email, first and last name, and payment conference year, and adds a custom Ransack ransacker to disambiguate the `conf_year` field. Minor improvements and cleanups are also included.

**Admin filter improvements:**

* Added filters to `app/admin/applications.rb` for user email, first name, and last name, using joined queries to ensure only users with payments are included.
* Updated filters in `app/admin/payments.rb` to allow filtering by payer identity (user email), applicant's first and last name, and payment conference year, using joined queries and distinct values.

**Search and filtering logic enhancements:**

* Added a custom Ransack ransacker `payments_conf_year` in `Payment` to disambiguate the `conf_year` field when filtering through associations, and updated `ransackable_attributes` accordingly.
* Updated the payment spec to expect the new `payments_conf_year` attribute.

**Minor fixes and cleanups:**

* Fixed manual payment link to use the correct user ID parameter in `app/admin/applications.rb`.
* Cleaned up unused code and comments in `app/admin/payments.rb` and made minor display tweaks.