### PR TITLE
Update dependencies and refactor ActiveAdmin filters for clarity

### DIFF
--- a/app/admin/applications.rb
+++ b/app/admin/applications.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Application do
   filter :lodging_selection, as: :select, collection: -> { Lodging.all.map { |lapp| [lapp.description, lapp.description]}.sort }
   filter :partner_registration_id, as: :select, collection: -> { PartnerRegistration.all.map { |papp| [papp.description, papp.id]}.sort }
   filter :subscription, as: :select
-  filter :conf_year, as: :select
+  filter :applications_conf_year, as: :select, label: "Conf Year"
 
   controller do
     before_action :load_index_batch_data, only: [:index]

--- a/app/admin/applications.rb
+++ b/app/admin/applications.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Application do
-  menu parent: "User Mangement", priority: 1
+  menu parent: "User Management", priority: 1
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register User do
-  menu parent: "User Mangement", priority: 3
+  menu parent: "User Management", priority: 3
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -67,7 +67,12 @@ class Application < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["accessibility_requirements", "birth_year", "city", "conf_year", "country", "created_at", "email", "email_confirmation", "first_name", "food_restrictions", "gender", "how_did_you_hear", "id", "id_value", "last_name", "lodging_selection", "lottery_position", "offer_status", "offer_status_date", "partner_first_name", "partner_last_name", "partner_registration_id", "partner_registration_selection", "phone", "result_email_sent", "special_lodging_request", "state", "street", "street2", "subscription", "updated_at", "user_id", "workshop_selection1", "workshop_selection2", "workshop_selection3", "zip"]
+    ["accessibility_requirements", "applications_conf_year", "birth_year", "city", "conf_year", "country", "created_at", "email", "email_confirmation", "first_name", "food_restrictions", "gender", "how_did_you_hear", "id", "id_value", "last_name", "lodging_selection", "lottery_position", "offer_status", "offer_status_date", "partner_first_name", "partner_last_name", "partner_registration_id", "partner_registration_selection", "phone", "result_email_sent", "special_lodging_request", "state", "street", "street2", "subscription", "updated_at", "user_id", "workshop_selection1", "workshop_selection2", "workshop_selection3", "zip"]
+  end
+
+  # Disambiguate conf_year when joining associated tables in Ransack searches.
+  ransacker :applications_conf_year do |parent|
+    parent.table[:conf_year]
   end
 
   HOW_DID_YOU_HEAR = ["---", "Word of Mouth", "Magazine Advertisement", "Online Advertisement", "Newspaper Advertisement", "Other"]

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -44,7 +44,7 @@ class Payment < ApplicationRecord
   end
 
 
-  scope :current_conference_payments, -> { where('conf_year = ? ', ApplicationSetting.get_current_app_year) }
+  scope :current_conference_payments, -> { where(arel_table[:conf_year].eq(ApplicationSetting.get_current_app_year)) }
 
   def manual_payment_decimal
     if self.transaction_type == "ManuallyEntered"

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe Application, type: :model do
     describe '.ransackable_attributes' do
       it 'returns the correct attributes' do
         expected_attributes = [
-          "accessibility_requirements", "birth_year", "city", "conf_year", "country",
+          "accessibility_requirements", "applications_conf_year", "birth_year", "city", "conf_year", "country",
           "created_at", "email", "email_confirmation", "first_name", "food_restrictions",
           "gender", "how_did_you_hear", "id", "id_value", "last_name", "lodging_selection",
           "lottery_position", "offer_status", "offer_status_date", "partner_first_name",


### PR DESCRIPTION
This pull request focuses on improving the admin interface and search functionality for applications and users, mainly by correcting UI labels and enhancing how the `conf_year` attribute is handled in Ransack searches to avoid ambiguity. Additionally, it includes a minor fix to a database query and updates related tests.

**Admin UI improvements:**
- Corrected the spelling of the "User Management" menu label in both `app/admin/applications.rb` and `app/admin/users.rb` for consistency and professionalism. 
- Updated the filter for conference year in the applications admin page to use a disambiguated label and attribute (`applications_conf_year`), making it clearer and preventing conflicts when joining associated tables.

**Search and filtering enhancements:**
- Added a new Ransack ransacker `applications_conf_year` to the `Application` model to disambiguate the `conf_year` field in complex searches, and included it in the list of ransackable attributes.
- Updated the related RSpec test to include `applications_conf_year` in the expected ransackable attributes, ensuring test coverage for this change.

**Code quality and query improvements:**
- Refactored the `current_conference_payments` scope in the `Payment` model to use Arel for better query safety and clarity.