### PR TITLE
Add account_type validation for manual payments in Payment model

### DIFF
--- a/app/admin/payments.rb
+++ b/app/admin/payments.rb
@@ -92,7 +92,7 @@ ActiveAdmin.register Payment do
       f.input :transaction_id, as: :hidden, :input_html => { value: DateTime.now.iso8601 + "_" + current_admin_user.email } # DateTime.now.iso8601 + current_admin_user.email
       f.input :total_amount, label: "Total amount in $" # 10000 => 100.00
       f.input :transaction_date, as: :datepicker # DateTime.now.iso8601
-      f.input :account_type, collection: ['scholarship', 'special', 'other']
+      f.input :account_type, collection: ['scholarship', 'special', 'other'], required: true
       f.input :result_code, as: :hidden, :input_html => { value: "Manually Entered" } # 'Manually Entered'
       f.input :result_message, as: :hidden, :input_html => { value: "This was manually entered by #{current_admin_user.email}" }
       f.input :timestamp, as: :hidden, :input_html => { value: DateTime.now.strftime("%Q").to_i }

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -24,6 +24,7 @@ class Payment < ApplicationRecord
   validates :transaction_id, presence: true, uniqueness: true
   validates :total_amount, presence: true
   validates :transaction_date, presence: true
+  validates :account_type, presence: true, if: :manual_entry?
   belongs_to :user
   validate :manual_payment_decimal
   validate :valid_transaction_date
@@ -45,6 +46,10 @@ class Payment < ApplicationRecord
 
 
   scope :current_conference_payments, -> { where(arel_table[:conf_year].eq(ApplicationSetting.get_current_app_year)) }
+
+  def manual_entry?
+    transaction_type == "ManuallyEntered"
+  end
 
   def manual_payment_decimal
     if self.transaction_type == "ManuallyEntered"

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -52,7 +52,7 @@ class Payment < ApplicationRecord
   end
 
   def manual_payment_decimal
-    if self.transaction_type == "ManuallyEntered"
+    if manual_entry?
       if self.total_amount !~ /^\s*[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?\s*$/
         errors.add(:total_amount, "must be decimal")
       elsif self.total_amount.to_f < 0
@@ -72,7 +72,7 @@ class Payment < ApplicationRecord
   end
 
   def check_manual_amount
-    if self.transaction_type == "ManuallyEntered"
+    if manual_entry?
       self.total_amount = (self.total_amount.to_f * 100).to_s
     end
   end

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -86,6 +86,17 @@ RSpec.describe PaymentsController, type: :controller do
             expect(payment.payer_identity).to eq(user.email)
             expect(payment.conf_year).to eq(ApplicationSetting.get_current_app_year)
           end
+
+          it 'creates a payment even when account_type is missing from gateway params' do
+            expect {
+              post :payment_receipt, params: valid_params.except(:transactionAcountType)
+            }.to change(Payment, :count).by(1)
+
+            payment = Payment.last
+            expect(payment.account_type).to be_nil
+            expect(payment.transaction_type).to eq('Credit')
+            expect(payment.transaction_id).to eq('test_transaction_123')
+          end
         end
 
         context 'when transaction_id already exists' do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe Payment, type: :model do
       expect(payment).not_to be_valid
     end
 
+    context 'when transaction_type is ManuallyEntered and account_type is present' do
+      it 'is valid' do
+        payment = build(:payment, :manual, account_type: 'scholarship')
+        expect(payment).to be_valid
+      end
+    end
+
+    context 'when transaction_type is ManuallyEntered and account_type is missing' do
+      it 'is not valid' do
+        payment = build(:payment, :manual, account_type: nil)
+        expect(payment).not_to be_valid
+        expect(payment.errors[:account_type]).to include("can't be blank")
+      end
+    end
+
     context 'when transaction_type is ManuallyEntered' do
       it 'validates that total_amount is a decimal' do
         payment = build(:payment, transaction_type: 'ManuallyEntered', total_amount: 'not_a_number')

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe Payment, type: :model do
       end
     end
 
+    context 'when transaction_type is not ManuallyEntered' do
+      it 'is valid without an account_type' do
+        payment = build(:payment, transaction_type: 'Credit', account_type: nil)
+        expect(payment).to be_valid
+      end
+    end
+
     context 'when transaction_type is ManuallyEntered' do
       it 'validates that total_amount is a decimal' do
         payment = build(:payment, transaction_type: 'ManuallyEntered', total_amount: 'not_a_number')


### PR DESCRIPTION
This pull request strengthens validation for the `account_type` field in the `Payment` model, ensuring that it is required for manually entered payments. It also updates the admin interface and adds comprehensive tests to cover these scenarios.

**Validation improvements for manual payments:**

* Added a conditional validation to require `account_type` when `transaction_type` is `"ManuallyEntered"` in the `Payment` model.
* Introduced the `manual_entry?` helper method to encapsulate the logic for identifying manual entries.

**Admin interface update:**

* Updated the `account_type` field in the ActiveAdmin `payments` form to be marked as required.

**Test coverage enhancements:**

* Added model specs to verify that `account_type` is required for manual payments and optional otherwise.
* Added a controller spec to ensure that payments can still be created via the gateway even if `account_type` is missing, as long as the payment is not manually entered.