### PR TITLE
Special_account_listing

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -17,6 +17,7 @@ ActiveAdmin.register_page "Dashboard" do
     special_invitees = Payment.current_conference_payments
                               .where(account_type: %w[special scholarship])
                               .includes(:user)
+                              .order(created_at: :desc, id: :desc)
                               .group_by(&:user_id)
                               .map { |_user_id, payments| payments.first }
                               .sort_by { |payment| payment.user.email.to_s.downcase }

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -14,12 +14,44 @@ ActiveAdmin.register_page "Dashboard" do
       end
     end
 
+    special_invitees = Payment.current_conference_payments
+                              .where(account_type: %w[special scholarship])
+                              .includes(:user)
+                              .group_by(&:user_id)
+                              .map { |_user_id, payments| payments.first }
+                              .sort_by { |payment| payment.user.email.to_s.downcase }
+
     columns do
       column do
-        panel "Recent #{ApplicationSetting.get_current_app_year} Applications" do
-          applications = Array(Application.active_conference_applications).select { |app| app.respond_to?(:display_name) }
-          table_for applications do
+        current_year_applications = Array(Application.active_conference_applications).select { |app| app.respond_to?(:display_name) }
+        current_year_application_count = current_year_applications.count
+        recent_applications = current_year_applications.sort_by { |app| app.respond_to?(:created_at) ? app.created_at : Time.at(0) }.reverse.first(25)
+
+        panel "Latest 25 of #{current_year_application_count} Applications for the #{ApplicationSetting.get_current_app_year} conference" do
+          table_for recent_applications do
             column(:id) { |app| link_to(app.display_name, admin_application_path(app)) }
+          end
+          div do
+            link_to 'See all current applications', admin_applications_path(q: { applications_conf_year_eq: ApplicationSetting.get_current_app_year })
+          end
+        end
+      end
+
+      column do
+        panel "Special invitees (#{special_invitees.size})" do
+          table_for special_invitees do
+            column('Email Address') { |payment| payment.user.email }
+            column('Application Status') do |payment|
+              application = payment.user.applications.where(conf_year: payment.conf_year).order(:created_at).last
+
+              if application.present?
+                full_name = "#{application.first_name} #{application.last_name}".squish
+                link_to(full_name, admin_application_path(application))
+              else
+                "Needs to submit an application to #{ApplicationSetting.get_current_app_year}"
+              end
+            end
+            column('Account Type') { |payment| payment.account_type }
           end
         end
       end
@@ -39,7 +71,6 @@ ActiveAdmin.register_page "Dashboard" do
           end
         end
       end
-
     end
 
     begin

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -23,9 +23,9 @@ ActiveAdmin.register_page "Dashboard" do
 
     columns do
       column do
-        current_year_applications = Array(Application.active_conference_applications).select { |app| app.respond_to?(:display_name) }
-        current_year_application_count = current_year_applications.count
-        recent_applications = current_year_applications.sort_by { |app| app.respond_to?(:created_at) ? app.created_at : Time.at(0) }.reverse.first(25)
+        current_year_applications_scope = Application.active_conference_applications
+        current_year_application_count = current_year_applications_scope.count
+        recent_applications = current_year_applications_scope.order(created_at: :desc).limit(25)
 
         panel "Latest 25 of #{current_year_application_count} Applications for the #{ApplicationSetting.get_current_app_year} conference" do
           table_for recent_applications do

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -20,6 +20,15 @@ ActiveAdmin.register_page "Dashboard" do
                               .group_by(&:user_id)
                               .map { |_user_id, payments| payments.first }
                               .sort_by { |payment| payment.user.email.to_s.downcase }
+    invitee_user_ids = special_invitees.map(&:user_id).uniq
+    invitee_conf_years = special_invitees.map(&:conf_year).uniq
+    latest_applications_by_user_and_year =
+      Application.where(user_id: invitee_user_ids, conf_year: invitee_conf_years)
+                 .order(created_at: :desc)
+                 .each_with_object({}) do |application, apps_by_user_and_year|
+        key = [application.user_id, application.conf_year]
+        apps_by_user_and_year[key] ||= application
+      end
 
     columns do
       column do
@@ -42,7 +51,7 @@ ActiveAdmin.register_page "Dashboard" do
           table_for special_invitees do
             column('Email Address') { |payment| payment.user.email }
             column('Application Status') do |payment|
-              application = payment.user.applications.where(conf_year: payment.conf_year).order(:created_at).last
+              application = latest_applications_by_user_and_year[[payment.user_id, payment.conf_year]]
 
               if application.present?
                 full_name = "#{application.first_name} #{application.last_name}".squish

--- a/app/controllers/application_settings_controller.rb
+++ b/app/controllers/application_settings_controller.rb
@@ -36,7 +36,7 @@ class ApplicationSettingsController < ApplicationController
           render turbo_stream: turbo_stream.replace(@application_setting, partial: "application_settings/form", locals: { application_setting: @application_setting })
         end
         format.html { render :new }
-        format.json { render json: @application_setting.errors, status: :unprocessable_entity }
+        format.json { render json: @application_setting.errors, status: :unprocessable_content }
       end
     end
   end
@@ -53,7 +53,7 @@ class ApplicationSettingsController < ApplicationController
           render turbo_stream: turbo_stream.replace(@application_setting, partial: "application_settings/form", locals: { application_setting: @application_setting })
         end
         format.html { render :edit }
-        format.json { render json: @application_setting.errors, status: :unprocessable_entity }
+        format.json { render json: @application_setting.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -49,7 +49,7 @@ class ApplicationsController < ApplicationController
           render turbo_stream: turbo_stream.replace(@application, partial: "applications/form", locals: { application: @application })
         end
         format.html { render :new }
-        format.json { render json: @application.errors, status: :unprocessable_entity }
+        format.json { render json: @application.errors, status: :unprocessable_content }
       end
     end
   end
@@ -71,7 +71,7 @@ class ApplicationsController < ApplicationController
           render turbo_stream: turbo_stream.replace(@application, partial: "applications/form", locals: { application: @application })
         end
         format.html { render :edit }
-        format.json { render json: @application.errors, status: :unprocessable_entity }
+        format.json { render json: @application.errors, status: :unprocessable_content }
       end
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -302,7 +302,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe PaymentsController, type: :controller do
           timestamp: Time.current.to_i.to_s,
           hash: 'valid_hash_here'
         }
-        expect(response).not_to have_http_status(:unprocessable_entity)
+        expect(response).not_to have_http_status(:unprocessable_content)
       end
 
       it 'requires user authentication for most actions' do

--- a/spec/requests/admin_dashboard_spec.rb
+++ b/spec/requests/admin_dashboard_spec.rb
@@ -31,5 +31,48 @@ RSpec.describe 'Admin Dashboard', type: :request do
       expect(response).to be_successful
       expect(response.body).to include('noapp@example.com ( - waiting for application to be submitted)')
     end
+
+    it 'shows special invitees with application status and account type' do
+      application_setting = ApplicationSetting.create!(
+        contest_year: Time.current.year,
+        opendate: Time.current,
+        subscription_cost: 0,
+        application_buffer: 1,
+        registration_fee: 50,
+        lottery_buffer: 50,
+        application_open_period: 48,
+        active_application: true
+      )
+
+      special_user = create(:user, email: 'special@example.com')
+      scholarship_user = create(:user, email: 'scholarship@example.com')
+      other_user = create(:user, email: 'other@example.com')
+
+      create(:payment, :special, user: special_user, conf_year: application_setting.contest_year)
+      create(:payment, :scholarship, user: scholarship_user, conf_year: application_setting.contest_year)
+      create(:payment, user: other_user, conf_year: application_setting.contest_year)
+
+      application = create(
+        :application,
+        user: special_user,
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        conf_year: application_setting.contest_year,
+        partner_registration: create(:partner_registration)
+      )
+
+      get admin_root_path
+
+      expect(response).to be_successful
+      expect(response.body).to include('Special invitees (2)')
+      expect(response.body).to include('special@example.com')
+      expect(response.body).to include('scholarship@example.com')
+      expect(response.body).to include('Needs to submit an application to')
+      expect(response.body).to include('special')
+      expect(response.body).to include('scholarship')
+      expect(response.body).to include("href=\"#{admin_application_path(application)}\"")
+      expect(response.body).to include('Ada Lovelace')
+      expect(response.body.index('scholarship@example.com')).to be < response.body.index('special@example.com')
+    end
   end
 end

--- a/spec/requests/admin_dashboard_spec.rb
+++ b/spec/requests/admin_dashboard_spec.rb
@@ -7,14 +7,9 @@ RSpec.describe 'Admin Dashboard', type: :request do
     before { sign_in admin_user }
 
     it 'displays user email when payment has no current application' do
-      application_setting = ApplicationSetting.create!(
+      application_setting = create(
+        :application_setting,
         contest_year: Time.current.year,
-        opendate: Time.current,
-        subscription_cost: 0,
-        application_buffer: 1,
-        registration_fee: 50,
-        lottery_buffer: 50,
-        application_open_period: 48,
         active_application: true
       )
 
@@ -33,14 +28,9 @@ RSpec.describe 'Admin Dashboard', type: :request do
     end
 
     it 'shows special invitees with application status and account type' do
-      application_setting = ApplicationSetting.create!(
+      application_setting = create(
+        :application_setting,
         contest_year: Time.current.year,
-        opendate: Time.current,
-        subscription_cost: 0,
-        application_buffer: 1,
-        registration_fee: 50,
-        lottery_buffer: 50,
-        application_open_period: 48,
         active_application: true
       )
 

--- a/spec/requests/application_settings_spec.rb
+++ b/spec/requests/application_settings_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "ApplicationSettings", type: :request do
           post application_settings_path, params: {
             application_setting: { contest_year: nil } # Invalid params
           }, as: :json
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe "ApplicationSettings", type: :request do
           patch application_setting_path(application_setting), params: {
             application_setting: { contest_year: nil } # Invalid params
           }, as: :json
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/requests/applications_spec.rb
+++ b/spec/requests/applications_spec.rb
@@ -78,17 +78,9 @@ RSpec.describe "Applications", type: :request do
         # Removing "does not create a new Application" test since it was skipped
 
         it "renders a response with 422 status (i.e. to display the 'new' template)" do
-          # Keep this test as it was not skipped
-          mock_application = instance_double(Application, save: false)
-          allow(Application).to receive(:new).and_return(mock_application)
-          allow(mock_application).to receive(:email=)
-          allow(mock_application).to receive(:user=)
-          allow(mock_application).to receive(:errors).and_return(double(empty?: false))
-
-          allow_any_instance_of(ApplicationsController).to receive(:render).and_return(nil)
-          allow_any_instance_of(ActionDispatch::Response).to receive(:status).and_return(422)
-
-          post applications_path, params: { application: { first_name: nil } }
+          post applications_path,
+               params: { application: valid_attributes.merge(first_name: nil) },
+               as: :json
           expect(response).to have_http_status(:unprocessable_content)
         end
       end

--- a/spec/requests/applications_spec.rb
+++ b/spec/requests/applications_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Applications", type: :request do
           allow_any_instance_of(ActionDispatch::Response).to receive(:status).and_return(422)
 
           post applications_path, params: { application: { first_name: nil } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/support/application_mock.rb
+++ b/spec/support/application_mock.rb
@@ -13,6 +13,9 @@ RSpec.configure do |config|
     allow(mock_active_applications).to receive(:last).and_return(nil)
     allow(mock_active_applications).to receive(:pluck).and_return([])
     allow(mock_active_applications).to receive(:each).and_return([])
+    allow(mock_active_applications).to receive(:count).and_return(0)
+    allow(mock_active_applications).to receive(:order).and_return(mock_active_applications)
+    allow(mock_active_applications).to receive(:limit).and_return([])
 
     # Mock the Application.active_conference_applications class method
     allow(Application).to receive(:active_conference_applications).and_return(mock_active_applications)


### PR DESCRIPTION
This pull request introduces a new "Special invitees" panel to the admin dashboard, displaying users with "special" or "scholarship" payment types and their application status. Additionally, it standardizes the HTTP error status used for invalid requests from `:unprocessable_entity` to `:unprocessable_content` across controllers, initializers, and tests. Relevant tests have been added and updated to cover these changes.

**Admin dashboard enhancements:**

* Added a "Special invitees" panel to `app/admin/dashboard.rb` that lists users with "special" or "scholarship" payments, showing their email, application status (with link if available), and account type. Also improved the applications panel to show the latest 25 applications and a count of total applications. [[1]](diffhunk://#diff-0a54db191e26dec999c69389133b80adf876475a89be1c4ad70bea54e0d453ddR17-R55) [[2]](diffhunk://#diff-0a54db191e26dec999c69389133b80adf876475a89be1c4ad70bea54e0d453ddL42)
* Added a request spec to verify the presence and correctness of the new "Special invitees" panel and its data.

**HTTP status code standardization:**

* Changed all controller responses for invalid resource creation or update from `:unprocessable_entity` (422) to `:unprocessable_content` (422), including in `applications_controller.rb`, `application_settings_controller.rb`, and the Devise initializer. 
* Updated related specs to expect `:unprocessable_content` instead of `:unprocessable_entity`. 