### PR TITLE
Enhance payment processing and admin dashboard filtering

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -14,8 +14,9 @@ ActiveAdmin.register_page "Dashboard" do
       end
     end
 
+    # Only special payment invitees (not scholarship or other account types).
     special_invitees = Payment.current_conference_payments
-                              .where(account_type: %w[special scholarship])
+                              .where(account_type: 'special')
                               .includes(:user)
                               .order(created_at: :desc, id: :desc)
                               .group_by(&:user_id)

--- a/app/admin/payments.rb
+++ b/app/admin/payments.rb
@@ -22,6 +22,8 @@ ActiveAdmin.register Payment do
   filter :payments_conf_year, as: :select,
     collection: -> { Payment.order(:conf_year).distinct.pluck(:conf_year) },
     label: "Payment Conf Year"
+  filter :account_type, as: :select,
+    collection: -> { Payment.order(:account_type).distinct.pluck(:account_type).compact }
 
   index do
     selectable_column

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -123,8 +123,17 @@
       end
 
       def validated_payment_amount(raw_amount)
+        return nil if raw_amount.respond_to?(:blank?) ? raw_amount.blank? : raw_amount.nil?
+
         amount = Integer(raw_amount, exception: false)
-        return nil if amount.nil? || amount <= 0
+        if amount.nil?
+          begin
+            amount = BigDecimal(raw_amount.to_s).to_i
+          rescue ArgumentError
+            return nil
+          end
+        end
+        return nil if amount <= 0
 
         balance_due = current_balance_due
         return nil if balance_due <= 0

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -168,10 +168,10 @@ RSpec.describe PaymentsController, type: :controller do
       end
 
       context 'with different amounts' do
-        it 'rejects decimal amounts' do
+        it 'truncates dollar-and-cent strings to whole dollars (Nelnet uses integer dollars)' do
           post :make_payment, params: { amount: '50.50' }
-          expect(response).to redirect_to(all_payments_path)
-          expect(flash[:alert]).to eq('Please enter a valid payment amount.')
+          expect(response).to be_redirect
+          expect(response.location).to include('amountDue=5000')
         end
 
         it 'rejects zero amount' do

--- a/spec/requests/admin_dashboard_spec.rb
+++ b/spec/requests/admin_dashboard_spec.rb
@@ -35,12 +35,8 @@ RSpec.describe 'Admin Dashboard', type: :request do
       )
 
       special_user = create(:user, email: 'special@example.com')
-      scholarship_user = create(:user, email: 'scholarship@example.com')
-      other_user = create(:user, email: 'other@example.com')
 
       create(:payment, :special, user: special_user, conf_year: application_setting.contest_year)
-      create(:payment, :scholarship, user: scholarship_user, conf_year: application_setting.contest_year)
-      create(:payment, user: other_user, conf_year: application_setting.contest_year)
 
       application = create(
         :application,
@@ -54,15 +50,11 @@ RSpec.describe 'Admin Dashboard', type: :request do
       get admin_root_path
 
       expect(response).to be_successful
-      expect(response.body).to include('Special invitees (2)')
+      expect(response.body).to include('Special invitees (1)')
       expect(response.body).to include('special@example.com')
-      expect(response.body).to include('scholarship@example.com')
-      expect(response.body).to include('Needs to submit an application to')
       expect(response.body).to include('special')
-      expect(response.body).to include('scholarship')
       expect(response.body).to include("href=\"#{admin_application_path(application)}\"")
       expect(response.body).to include('Ada Lovelace')
-      expect(response.body.index('scholarship@example.com')).to be < response.body.index('special@example.com')
     end
   end
 end

--- a/spec/requests/conference_closed_spec.rb
+++ b/spec/requests/conference_closed_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Opt out of spec/support/application_setting_mock.rb and application_mock.rb so views use real
+# ApplicationSetting rows and Application.active_conference_applications (see those files).
+RSpec.describe 'Conference closed page', type: :request, real_application_settings: true do
+  # Avoid multiple active ApplicationSetting rows: get_current_app_settings uses active.first (unordered).
+  before { ApplicationSetting.delete_all }
+
+  let(:conf_year) { Time.current.year }
+  let(:user) { create(:user, email: "conference-closed-#{SecureRandom.hex(8)}@example.com") }
+  let!(:lodging) { create(:lodging, description: 'Standard', cost: 100.0) }
+  let(:partner_registration) { create(:partner_registration, cost: 75.0) }
+
+  let!(:application_setting) do
+    create(
+      :application_setting,
+      active_application: true,
+      contest_year: conf_year,
+      opendate: 1.month.ago,
+      application_open_period: 48,
+      application_closed_directions: '<p>UniqueClosedDirectionsHtml</p>',
+      registration_fee: 50.0
+    )
+  end
+
+  def create_active_application(offer_status:)
+    create(
+      :application,
+      user: user,
+      email: user.email,
+      email_confirmation: user.email,
+      conf_year: application_setting.contest_year,
+      offer_status: offer_status,
+      partner_registration: partner_registration,
+      lodging_selection: 'Standard'
+    )
+  end
+
+  describe 'GET /conference_closed' do
+    context 'when the user is signed in with an offer and no payments' do
+      before { sign_in user }
+
+      %w[registration_offered registration_accepted].each do |status|
+        it "shows the application fee payment button when offer_status is #{status}" do
+          create_active_application(offer_status: status)
+
+          get conference_closed_path
+
+          expect(response).to be_successful
+          expect(response.body).to include('To accept your offer')
+          expect(response.body).to include('Pay the Application Fee')
+          expect(response.body).to include('make_payment')
+        end
+      end
+    end
+
+    context 'when the user is signed in with an offer but already has a conference payment' do
+      before { sign_in user }
+
+      it 'shows the payments sidebar message instead of the pay button' do
+        create_active_application(offer_status: 'registration_offered')
+        create(
+          :payment,
+          :current_conference,
+          user: user,
+          transaction_status: '1',
+          conf_year: application_setting.contest_year
+        )
+
+        get conference_closed_path
+
+        expect(response).to be_successful
+        expect(response.body).to include(
+          "You may use the links in the 'Your Details' box to the right to view or manage your payments."
+        )
+        expect(response.body).not_to include('Pay the Application Fee')
+      end
+    end
+
+    context 'when the user is signed in but offer_status is not offered or accepted' do
+      before { sign_in user }
+
+      it 'shows application_closed_directions instead of the pay button' do
+        create_active_application(offer_status: 'not_offered')
+
+        get conference_closed_path
+
+        expect(response).to be_successful
+        expect(response.body).to include('UniqueClosedDirectionsHtml')
+        expect(response.body).not_to include('Pay the Application Fee')
+      end
+    end
+
+    context 'when opendate is in the future (pre-open messaging)' do
+      before do
+        sign_in user
+        application_setting.update!(opendate: 1.month.from_now)
+        create_active_application(offer_status: 'registration_offered')
+      end
+
+      it 'shows the upcoming application window copy, not the pay button' do
+        get conference_closed_path
+
+        expect(response).to be_successful
+        expect(response.body).to include('Thank you for your interest in Bear River.')
+        expect(response.body).not_to include('Pay the Application Fee')
+      end
+    end
+
+    context 'when the visitor is not signed in' do
+      it 'shows application_closed_directions' do
+        get conference_closed_path
+
+        expect(response).to be_successful
+        expect(response.body).to include('UniqueClosedDirectionsHtml')
+        expect(response.body).not_to include('Pay the Application Fee')
+      end
+    end
+  end
+end

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe "Payments", type: :request do
         expect(response).to redirect_to("https://payment-url.example.com")
       end
 
+      it "accepts whole-dollar amounts formatted like decimals (e.g. registration_fee from DB)" do
+        expect_any_instance_of(PaymentsController)
+          .to receive(:generate_hash).with(user, 50).and_return("https://payment-url.example.com")
+
+        post make_payment_path, params: { amount: "50.0" }
+        expect(response).to redirect_to("https://payment-url.example.com")
+      end
+
       it "rejects missing amount input" do
         post make_payment_path, params: { amount: "" }
         expect(response).to redirect_to(all_payments_path)

--- a/spec/support/application_mock.rb
+++ b/spec/support/application_mock.rb
@@ -1,7 +1,9 @@
 RSpec.configure do |config|
-  config.before(:each, type: :request) do
+  config.before(:each, type: :request) do |example|
     # Skip mock when testing admin applications index (needs real ActiveRecord chain)
-    next if RSpec.current_example.metadata[:no_application_mock]
+    next if example.metadata[:no_application_mock]
+    # Skip when using real ApplicationSetting rows (same examples need real scopes; see conference_closed_spec)
+    next if example.metadata[:real_application_settings]
 
     # Create a mock for Application.active_conference_applications
     mock_active_applications = double("ActiveApplications")

--- a/spec/support/application_setting_mock.rb
+++ b/spec/support/application_setting_mock.rb
@@ -1,5 +1,8 @@
 RSpec.configure do |config|
-  config.before(:each, type: :request) do
+  config.before(:each, type: :request) do |example|
+    # Tag examples with `real_application_settings: true` (or `:real_application_settings`) to use DB rows.
+    next if example.metadata[:real_application_settings]
+
     # Create a mock ApplicationSetting object
     mock_app_setting = double("ApplicationSetting",
       contest_year: Time.current.year,


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to payment handling, admin dashboard filtering, and test coverage for conference-closed scenarios. The main focus is on refining the logic for special invitees, enhancing payment amount validation to support decimal-formatted inputs, and adding comprehensive request specs for the conference closed page. Additionally, test support files are updated to better control when mocks are used.

**Payment handling improvements:**

* Updated `validated_payment_amount` in `PaymentsController` to accept whole-dollar amounts formatted as decimals (e.g., "50.0" or "50.50" are now parsed as 50), improving compatibility with external systems and database values.
* Adjusted payment specs to verify new behavior for decimal-formatted amounts, ensuring that values like "50.50" are truncated to whole dollars and accepted. [[1]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL171-R174) [[2]](diffhunk://#diff-0aa670eb81d633f5e5483670c8bbd95ad789afe41c73acb200177066e1af8430R100-R107)

**Admin dashboard and filtering:**

* Refined the selection of special invitees on the admin dashboard to include only users with the `account_type` of "special", excluding "scholarship" and other types. Related test expectations were updated accordingly. [[1]](diffhunk://#diff-0a54db191e26dec999c69389133b80adf876475a89be1c4ad70bea54e0d453ddR17-R19) [[2]](diffhunk://#diff-0be283532476c342dc708ece5d4ea42f39c42754763ef11d03da292e68552742L38-L43) [[3]](diffhunk://#diff-0be283532476c342dc708ece5d4ea42f39c42754763ef11d03da292e68552742L57-L65)
* Added a filter for `account_type` in the admin payments index, allowing admins to filter payments by account type.

**Test coverage and support improvements:**

* Added a comprehensive request spec for the conference closed page, covering various user states and ensuring correct messaging and button visibility.
* Enhanced test support files to allow opt-out of mocks via metadata (`real_application_settings`), enabling tests to use real database rows when necessary. [[1]](diffhunk://#diff-f44d8ca88cfccac9442d9e999fb332f407de55853451d56c727905fc0e516d26L2-R6) [[2]](diffhunk://#diff-7fadd4f44bce10e54abd014c0d5d90dd3134f1985fd7eed346f713350307441eL2-R5)