### PR TITLE
Enhance balance due email tracking and update Active Storage schema

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -91,6 +91,14 @@ ActiveAdmin.register_page "Dashboard" do
             span do
               button_to 'Send Balance Due email', send_balance_due_url, class: 'btn'
             end
+            span do
+              if current_application_settings.balance_due_emails_last_sent_at.present?
+                zone = current_application_settings.time_zone.presence || Time.zone.name
+                "Last sent: #{current_application_settings.balance_due_emails_last_sent_at.in_time_zone(zone).strftime('%B %-d, %Y at %-I:%M %p %Z')}"
+              else
+                'Last sent: never'
+              end
+            end
           end
         end
         column do

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -99,6 +99,7 @@ class ApplicationsController < ApplicationController
         message_count += 1
       end
     end
+    current_application_settings&.update(balance_due_emails_last_sent_at: Time.current)
     flash[:alert] = "#{message_count} balance due messages sent."
     redirect_to admin_root_path
   end

--- a/db/migrate/20260331160000_add_balance_due_emails_last_sent_at_to_application_settings.rb
+++ b/db/migrate/20260331160000_add_balance_due_emails_last_sent_at_to_application_settings.rb
@@ -1,0 +1,5 @@
+class AddBalanceDueEmailsLastSentAtToApplicationSettings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_settings, :balance_due_emails_last_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_04_203447) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_31_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,9 +54,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_04_203447) do
     t.string "content_type"
     t.text "metadata"
     t.bigint "byte_size", null: false
-    t.string "checksum", null: false
+    t.string "checksum"
     t.datetime "created_at", precision: nil, null: false
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", id: :serial, force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -99,6 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_04_203447) do
     t.text "application_confirm_email_message"
     t.text "balance_due_email_message"
     t.text "special_offer_invite_email"
+    t.datetime "balance_due_emails_last_sent_at"
   end
 
   create_table "applications", force: :cascade do |t|
@@ -211,6 +219,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_04_203447) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "applications", "partner_registrations"
   add_foreign_key "applications", "users"
   add_foreign_key "payments", "users"

--- a/spec/requests/applications_spec.rb
+++ b/spec/requests/applications_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe "Applications", type: :request do
     end
   end
 
-  describe "GET /send_balance_due" do
+  describe "GET /send_balance_due", :real_application_settings do
     context "when admin user is not signed in" do
       it "redirects to admin sign in page" do
         post send_balance_due_path
@@ -190,6 +190,8 @@ RSpec.describe "Applications", type: :request do
     end
 
     context "when admin user is signed in" do
+      let!(:application_setting) { create(:application_setting, active_application: true) }
+
       before do
         sign_in admin_user
         # Mock the mailer to prevent actual emails from being sent
@@ -201,6 +203,7 @@ RSpec.describe "Applications", type: :request do
         post send_balance_due_path
         expect(response).to redirect_to(admin_root_path)
         expect(flash[:alert]).to eq('1 balance due messages sent.')
+        expect(application_setting.reload.balance_due_emails_last_sent_at).to be_present
       end
     end
   end


### PR DESCRIPTION
This pull request adds tracking for when balance due emails are sent to applicants, displaying this information in the admin dashboard and persisting it in the database. It includes a database migration, updates to the admin UI, controller logic, and relevant tests.

**Database changes:**

* Added a new `balance_due_emails_last_sent_at` datetime column to the `application_settings` table to store the timestamp of the last sent balance due email. [[1]](diffhunk://#diff-ca47b4c8a7319193274fd11b95838c006ae66fa83ab913c5edca53c4f4d34de7R1-R5) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R109)

**Admin dashboard improvements:**

* Updated the admin dashboard (`dashboard.rb`) to display the last sent time for balance due emails, showing either the formatted timestamp or 'never' if no email has been sent.

**Controller logic:**

* Modified the `send_balance_due` action to update the `balance_due_emails_last_sent_at` field whenever balance due emails are sent.

**Testing enhancements:**

* Updated request specs to ensure the `balance_due_emails_last_sent_at` field is correctly set after sending emails, and improved test setup for application settings. [[1]](diffhunk://#diff-346134d6625ef39deff406b2a7d705341900ff8c54c27bf9a02b730062068ca3L184-R184) [[2]](diffhunk://#diff-346134d6625ef39deff406b2a7d705341900ff8c54c27bf9a02b730062068ca3R193-R194) [[3]](diffhunk://#diff-346134d6625ef39deff406b2a7d705341900ff8c54c27bf9a02b730062068ca3R206)

**Schema updates:**

* Refreshed `db/schema.rb` to reflect the new column and related database structure changes. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L57-R68) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R222)