### PR TITLE
Fix pmnt recordings

### DIFF
--- a/app/admin/payment_gateway_callbacks.rb
+++ b/app/admin/payment_gateway_callbacks.rb
@@ -1,0 +1,55 @@
+ActiveAdmin.register PaymentGatewayCallback do
+  menu parent: 'User Management', priority: 2.5, label: 'Gateway callbacks'
+
+  actions :index, :show
+
+  config.sort_order = 'created_at_desc'
+
+  filter :transaction_id
+  filter :processing_status, as: :select, collection: PaymentGatewayCallback::PROCESSING_STATUSES
+  filter :event_type
+  filter :user
+  filter :payment
+  filter :created_at
+
+  index do
+    actions
+    column :id do |callback|
+      link_to callback.id, admin_payment_gateway_callback_path(callback)
+    end
+    column :transaction_id
+    column :processing_status
+    column :event_type
+    column :user
+    column :payment
+    column :failure_reason do |callback|
+      truncate(callback.failure_reason.to_s, length: 80)
+    end
+    column :created_at
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :transaction_id
+      row :processing_status
+      row :event_type
+      row :user do |callback|
+        if callback.user
+          link_to(callback.user.email, admin_user_path(callback.user))
+        end
+      end
+      row :payment do |callback|
+        if callback.payment
+          link_to("Payment ##{callback.payment.id}", admin_payment_path(callback.payment))
+        end
+      end
+      row :failure_reason
+      row :created_at
+      row :updated_at
+      row :payload do |callback|
+        pre JSON.pretty_generate(callback.payload.presence || {})
+      end
+    end
+  end
+end

--- a/app/admin/payments.rb
+++ b/app/admin/payments.rb
@@ -75,6 +75,26 @@ ActiveAdmin.register Payment do
       row :created_at
       row :updated_at
     end
+
+    panel 'Gateway callbacks' do
+      callbacks = payment.payment_gateway_callbacks.order(created_at: :desc)
+      if callbacks.any?
+        table_for callbacks do
+          column :id do |callback|
+            link_to(callback.id, admin_payment_gateway_callback_path(callback))
+          end
+          column :processing_status
+          column :transaction_id
+          column :failure_reason do |callback|
+            truncate(callback.failure_reason.to_s, length: 60)
+          end
+          column :created_at
+        end
+      else
+        para 'No gateway callback rows are linked to this payment. Callbacks are attached when a gateway receipt is successfully recorded for this row.'
+      end
+    end
+
     active_admin_comments
   end
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -7,9 +7,9 @@
     protect_from_forgery with: :exception
     skip_before_action :verify_authenticity_token, only: [:payment_receipt]
     before_action :verify_payment_callback, only: [:payment_receipt]
-    before_action :authenticate_user!, except: [:delete_manual_payment]
-    before_action :current_user, only: %i[payment_receipt make_payment payment_show]
-    before_action :current_application, only: %i[payment_receipt payment_show]
+  before_action :authenticate_user!, except: [:delete_manual_payment, :payment_receipt]
+  before_action :current_user, only: %i[make_payment payment_show]
+  before_action :current_application, only: %i[payment_show]
     before_action :authenticate_admin_user!, only: [:delete_manual_payment]
     prepend_before_action :verify_authenticity_token, only: [:delete_manual_payment]
 
@@ -18,27 +18,17 @@
     end
 
     def payment_receipt
-      if Payment.pluck(:transaction_id).include?(params['transactionId'])
+    result = Payments::GatewayReceiptRecorder.new(callback_params: url_params).call
+
+    case result.status
+    when :duplicate
         redirect_to all_payments_path
-      else
-        Payment.create(
-          transaction_type: params['transactionType'],
-          transaction_status: params['transactionStatus'],
-          transaction_id: params['transactionId'],
-          total_amount: params['transactionTotalAmount'],
-          transaction_date: params['transactionDate'],
-          account_type: params['transactionAcountType'],
-          result_code: params['transactionResultCode'],
-          result_message: params['transactionResultMessage'],
-          user_account: params['orderNumber'],
-          payer_identity: @current_user.email,
-          timestamp: params['timestamp'],
-          transaction_hash: params['hash'],
-          user_id: current_user.id,
-          conf_year: ApplicationSetting.get_current_app_year
-        )
-        @current_application.update(offer_status: "registration_accepted")
+    when :recorded
         redirect_to all_payments_path, notice: "Your Payment Was Successfully Recorded"
+    when :forbidden
+      head :forbidden
+    else
+      head :unprocessable_entity
       end
     end
 
@@ -75,7 +65,7 @@
 
     private
       def verify_payment_callback
-        unless params['hash'].present? && params['timestamp'].present? && params['transactionId'].present?
+      unless params['hash'].present? && params['timestamp'].present? && params['transactionId'].present? && params['orderNumber'].present?
           head :forbidden
           return
         end
@@ -170,4 +160,5 @@
       def current_application
         @current_application = Application.active_conference_applications.find_by(user_id: current_user)
       end
+
   end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,164 +1,166 @@
-  require 'digest'
-  require 'time'
+require 'digest'
+require 'time'
 
-  class PaymentsController < ApplicationController
-    MAX_PAYMENT_AMOUNT = 2000
+class PaymentsController < ApplicationController
+  MAX_PAYMENT_AMOUNT = 2000
 
-    protect_from_forgery with: :exception
-    skip_before_action :verify_authenticity_token, only: [:payment_receipt]
-    before_action :verify_payment_callback, only: [:payment_receipt]
-  before_action :authenticate_user!, except: [:delete_manual_payment, :payment_receipt]
+  protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token, only: [:payment_receipt]
+  before_action :verify_payment_callback, only: [:payment_receipt]
+
+  before_action :authenticate_user!, except: %i[delete_manual_payment payment_receipt]
   before_action :current_user, only: %i[make_payment payment_show]
   before_action :current_application, only: %i[payment_show]
-    before_action :authenticate_admin_user!, only: [:delete_manual_payment]
-    prepend_before_action :verify_authenticity_token, only: [:delete_manual_payment]
 
-    def index
-      redirect_to root_url
-    end
+  before_action :authenticate_admin_user!, only: [:delete_manual_payment]
+  prepend_before_action :verify_authenticity_token, only: [:delete_manual_payment]
 
-    def payment_receipt
+  def index
+    redirect_to root_url
+  end
+
+  def payment_receipt
     result = Payments::GatewayReceiptRecorder.new(callback_params: url_params).call
 
     case result.status
     when :duplicate
-        redirect_to all_payments_path
+      redirect_to all_payments_path
     when :recorded
-        redirect_to all_payments_path, notice: "Your Payment Was Successfully Recorded"
+      redirect_to all_payments_path, notice: 'Your Payment Was Successfully Recorded'
     when :forbidden
       head :forbidden
     else
       head :unprocessable_entity
-      end
     end
-
-    def make_payment
-      amount = validated_payment_amount(params['amount'])
-      if amount.nil?
-        redirect_to all_payments_path, alert: 'Please enter a valid payment amount.'
-        return
-      end
-
-      processed_url = generate_hash(current_user, amount)
-      redirect_to processed_url, allow_other_host: true
-    end
-
-    def payment_show
-      redirect_to root_url unless user_has_payments?(current_user)
-      @users_current_payments = Payment.current_conference_payments.where(user_id: current_user )
-      @ttl_paid = Payment.current_conference_payments.where(user_id: current_user, transaction_status: '1').pluck(:total_amount).map(&:to_f).sum / 100
-      @has_subscription = @current_application.subscription
-      @cost_subscription = @current_application.subscription_cost
-      @total_cost = @current_application.total_cost
-      @balance_due = @total_cost - @ttl_paid
-      @max_payment_amount = max_payment_amount_for(@balance_due)
-    end
-
-    def delete_manual_payment
-      @payment = Payment.find(params[:id])
-      @payment.destroy
-      respond_to do |format|
-        format.html { redirect_to admin_payments_url, notice: 'Payment was successfully deleted.' }
-        format.json { head :no_content }
-      end
-    end
-
-    private
-      def verify_payment_callback
-      unless params['hash'].present? && params['timestamp'].present? && params['transactionId'].present? && params['orderNumber'].present?
-          head :forbidden
-          return
-        end
-      end
-
-      def generate_hash(current_user, amount=100)
-        user_account = current_user.email.partition('@').first + '-' + current_user.id.to_s
-        amount_to_be_payed = amount.to_i
-        if Rails.env.development? || Rails.env.staging? || Rails.application.credentials.NELNET_SERVICE[:SERVICE_SELECTOR] == "QA"
-           key_to_use = 'test_key'
-           url_to_use = 'test_URL'
-         else
-           key_to_use = 'prod_key'
-           url_to_use = 'prod_URL'
-         end
-
-        connection_hash = {
-         'test_key' => Rails.application.credentials.NELNET_SERVICE[:DEVELOPMENT_KEY],
-         'test_URL' => Rails.application.credentials.NELNET_SERVICE[:DEVELOPMENT_URL],
-         'prod_key' => Rails.application.credentials.NELNET_SERVICE[:PRODUCTION_KEY],
-         'prod_URL' => Rails.application.credentials.NELNET_SERVICE[:PRODUCTION_URL]
-        }
-
-        redirect_url = connection_hash[url_to_use]
-        current_epoch_time = DateTime.now.strftime("%Q").to_i
-        initial_hash = {
-          'orderNumber' => user_account,
-          'orderType' => 'English Department Online',
-          'orderDescription' => 'Bearriver Conference Fees',
-          'amountDue' => amount_to_be_payed * 100,
-          'redirectUrl' => redirect_url,
-          'redirectUrlParameters' => 'transactionType,transactionStatus,transactionId,transactionTotalAmount,transactionDate,transactionAcountType,transactionResultCode,transactionResultMessage,orderNumber',
-          'retriesAllowed' => 1,
-          'timestamp' => current_epoch_time,
-          'key' => connection_hash[key_to_use]
-        }
-
-        # Sample Hash Creation
-        hash_to_be_encoded = initial_hash.values.map{|v| "#{v}"}.join('')
-        encoded_hash =  Digest::SHA256.hexdigest hash_to_be_encoded
-
-        # Final URL
-        url_for_payment = initial_hash.map{|k,v| "#{k}=#{v}&" unless k == 'key'}.join('')
-        final_url = connection_hash[url_to_use] + '?' + url_for_payment + 'hash=' + encoded_hash
-      end
-
-      def validated_payment_amount(raw_amount)
-        return nil if raw_amount.respond_to?(:blank?) ? raw_amount.blank? : raw_amount.nil?
-
-        amount = Integer(raw_amount, exception: false)
-        if amount.nil?
-          begin
-            amount = BigDecimal(raw_amount.to_s).to_i
-          rescue ArgumentError
-            return nil
-          end
-        end
-        return nil if amount <= 0
-
-        balance_due = current_balance_due
-        return nil if balance_due <= 0
-
-        max_amount = max_payment_amount_for(balance_due)
-        return nil if amount > max_amount
-
-        amount
-      end
-
-      def max_payment_amount_for(balance_due)
-        [balance_due.floor, MAX_PAYMENT_AMOUNT].min
-      end
-
-      def current_balance_due
-        current_application
-        return 0.0 if @current_application.nil?
-
-        total_cost = begin
-          @current_application.total_cost
-        rescue StandardError => e
-          Rails.logger.error("Error computing total_cost for application #{@current_application.id}: #{e.class}: #{e.message}") if defined?(Rails) && Rails.respond_to?(:logger)
-          0.0
-        end
-        total_cost = total_cost.to_f
-        total_paid = Payment.current_conference_payments.where(user_id: current_user, transaction_status: '1').pluck(:total_amount).map(&:to_f).sum / 100
-        total_cost - total_paid
-      end
-
-      def url_params
-        params.permit(:amount, :transactionType, :transactionStatus, :transactionId, :transactionTotalAmount, :transactionDate, :transactionAcountType, :transactionResultCode, :transactionResultMessage, :orderNumber, :timestamp, :hash, :conf_year)
-      end
-
-      def current_application
-        @current_application = Application.active_conference_applications.find_by(user_id: current_user)
-      end
-
   end
+
+  def make_payment
+    amount = validated_payment_amount(params['amount'])
+    if amount.nil?
+      redirect_to all_payments_path, alert: 'Please enter a valid payment amount.'
+      return
+    end
+
+    processed_url = generate_hash(current_user, amount)
+    redirect_to processed_url, allow_other_host: true
+  end
+
+  def payment_show
+    redirect_to root_url unless user_has_payments?(current_user)
+    @users_current_payments = Payment.current_conference_payments.where(user_id: current_user.id)
+    @ttl_paid = Payment.current_conference_payments.where(user_id: current_user.id, transaction_status: '1').pluck(:total_amount).map(&:to_f).sum / 100
+    @has_subscription = @current_application.subscription
+    @cost_subscription = @current_application.subscription_cost
+    @total_cost = @current_application.total_cost
+    @balance_due = @total_cost - @ttl_paid
+    @max_payment_amount = max_payment_amount_for(@balance_due)
+  end
+
+  def delete_manual_payment
+    @payment = Payment.find(params[:id])
+    @payment.destroy
+    respond_to do |format|
+      format.html { redirect_to admin_payments_url, notice: 'Payment was successfully deleted.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+  def verify_payment_callback
+    unless params['hash'].present? && params['timestamp'].present? && params['transactionId'].present? && params['orderNumber'].present?
+      head :forbidden
+      return
+    end
+  end
+
+  def generate_hash(current_user, amount = 100)
+    user_account = current_user.email.partition('@').first + '-' + current_user.id.to_s
+    amount_to_be_payed = amount.to_i
+    if Rails.env.development? || Rails.env.staging? || Rails.application.credentials.NELNET_SERVICE[:SERVICE_SELECTOR] == 'QA'
+      key_to_use = 'test_key'
+      url_to_use = 'test_URL'
+    else
+      key_to_use = 'prod_key'
+      url_to_use = 'prod_URL'
+    end
+
+    connection_hash = {
+      'test_key' => Rails.application.credentials.NELNET_SERVICE[:DEVELOPMENT_KEY],
+      'test_URL' => Rails.application.credentials.NELNET_SERVICE[:DEVELOPMENT_URL],
+      'prod_key' => Rails.application.credentials.NELNET_SERVICE[:PRODUCTION_KEY],
+      'prod_URL' => Rails.application.credentials.NELNET_SERVICE[:PRODUCTION_URL]
+    }
+
+    redirect_url = connection_hash[url_to_use]
+    current_epoch_time = DateTime.now.strftime('%Q').to_i
+    initial_hash = {
+      'orderNumber' => user_account,
+      'orderType' => 'English Department Online',
+      'orderDescription' => 'Bearriver Conference Fees',
+      'amountDue' => amount_to_be_payed * 100,
+      'redirectUrl' => redirect_url,
+      'redirectUrlParameters' => 'transactionType,transactionStatus,transactionId,transactionTotalAmount,transactionDate,transactionAcountType,transactionResultCode,transactionResultMessage,orderNumber',
+      'retriesAllowed' => 1,
+      'timestamp' => current_epoch_time,
+      'key' => connection_hash[key_to_use]
+    }
+
+    # Sample Hash Creation
+    hash_to_be_encoded = initial_hash.values.map { |v| "#{v}" }.join('')
+    encoded_hash = Digest::SHA256.hexdigest hash_to_be_encoded
+
+    # Final URL
+    url_for_payment = initial_hash.map { |k, v| "#{k}=#{v}&" unless k == 'key' }.join('')
+    connection_hash[url_to_use] + '?' + url_for_payment + 'hash=' + encoded_hash
+  end
+
+  def validated_payment_amount(raw_amount)
+    return nil if raw_amount.respond_to?(:blank?) ? raw_amount.blank? : raw_amount.nil?
+
+    amount = Integer(raw_amount, exception: false)
+    if amount.nil?
+      begin
+        amount = BigDecimal(raw_amount.to_s).to_i
+      rescue ArgumentError
+        return nil
+      end
+    end
+    return nil if amount <= 0
+
+    balance_due = current_balance_due
+    return nil if balance_due <= 0
+
+    max_amount = max_payment_amount_for(balance_due)
+    return nil if amount > max_amount
+
+    amount
+  end
+
+  def max_payment_amount_for(balance_due)
+    [balance_due.floor, MAX_PAYMENT_AMOUNT].min
+  end
+
+  def current_balance_due
+    current_application
+    return 0.0 if @current_application.nil?
+
+    total_cost = begin
+      @current_application.total_cost
+    rescue StandardError => e
+      Rails.logger.error("Error computing total_cost for application #{@current_application.id}: #{e.class}: #{e.message}") if defined?(Rails) && Rails.respond_to?(:logger)
+      0.0
+    end
+    total_cost = total_cost.to_f
+    total_paid = Payment.current_conference_payments.where(user_id: current_user.id, transaction_status: '1').pluck(:total_amount).map(&:to_f).sum / 100
+    total_cost - total_paid
+  end
+
+  def url_params
+    params.permit(:amount, :transactionType, :transactionStatus, :transactionId, :transactionTotalAmount, :transactionDate, :transactionAcountType, :transactionResultCode, :transactionResultMessage, :orderNumber, :timestamp, :hash, :conf_year)
+  end
+
+  def current_application
+    @current_application = Application.active_conference_applications.find_by(user_id: current_user.id)
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -26,12 +26,13 @@ class Payment < ApplicationRecord
   validates :transaction_date, presence: true
   validates :account_type, presence: true, if: :manual_entry?
   belongs_to :user
+  has_many :payment_gateway_callbacks, dependent: :nullify, inverse_of: :payment
   validate :manual_payment_decimal
   validate :valid_transaction_date
   before_save :check_manual_amount
 
   def self.ransackable_associations(auth_object = nil)
-    ["user"]
+    ["user", "payment_gateway_callbacks"]
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/payment_gateway_callback.rb
+++ b/app/models/payment_gateway_callback.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: payment_gateway_callbacks
+#
+#  id                :bigint           not null, primary key
+#  event_type        :string           default("receipt"), not null
+#  failure_reason    :text
+#  payload           :jsonb            not null
+#  processing_status :string           not null
+#  transaction_id    :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  payment_id        :bigint
+#  user_id           :bigint
+#
+class PaymentGatewayCallback < ApplicationRecord
+  PROCESSING_STATUSES = %w[recorded duplicate rejected error].freeze
+
+  belongs_to :payment, optional: true
+  belongs_to :user, optional: true
+
+  validates :processing_status, presence: true, inclusion: { in: PROCESSING_STATUSES }
+  validates :event_type, presence: true
+  validates :payload, presence: true
+end

--- a/app/models/payment_gateway_callback.rb
+++ b/app/models/payment_gateway_callback.rb
@@ -16,10 +16,21 @@
 class PaymentGatewayCallback < ApplicationRecord
   PROCESSING_STATUSES = %w[recorded duplicate rejected error].freeze
 
-  belongs_to :payment, optional: true
+  belongs_to :payment, optional: true, inverse_of: :payment_gateway_callbacks
   belongs_to :user, optional: true
 
   validates :processing_status, presence: true, inclusion: { in: PROCESSING_STATUSES }
   validates :event_type, presence: true
   validates :payload, presence: true
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[payment user]
+  end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[
+      created_at event_type failure_reason id id_value payload payment_id
+      processing_status transaction_id updated_at user_id
+    ]
+  end
 end

--- a/app/services/payments/gateway_receipt_recorder.rb
+++ b/app/services/payments/gateway_receipt_recorder.rb
@@ -1,0 +1,113 @@
+module Payments
+  class GatewayReceiptRecorder
+    # payment is only set for :recorded; other outcomes pass payment: nil explicitly for clarity.
+    Result = Struct.new(:status, :payment, keyword_init: true)
+
+    # Matches generate_hash: "<email_local_part>-<user_id>"
+    # Greedy .+ anchors the final "-<digits>" segment as user id (supports hyphens in local part).
+    ORDER_NUMBER_PATTERN = /\A(.+)-(\d+)\z/
+
+    def initialize(callback_params:)
+      @callback_params = callback_params.to_h
+    end
+
+    def call
+      callback_user = resolve_user_from_order_number
+      return callback_user if callback_user.is_a?(Result)
+
+      if Payment.exists?(transaction_id: transaction_id)
+        record_callback('duplicate', callback_user)
+        return Result.new(status: :duplicate, payment: nil)
+      end
+
+      payment = Payment.new(payment_attributes(callback_user))
+      if payment.save
+        current_application_for(callback_user)&.update(offer_status: 'registration_accepted')
+        record_callback('recorded', callback_user, payment)
+        Result.new(status: :recorded, payment: payment)
+      else
+        record_callback('error', callback_user, nil, payment.errors.full_messages.join(', '))
+        Result.new(status: :error, payment: nil)
+      end
+    end
+
+    private
+
+    attr_reader :callback_params
+
+    def transaction_id
+      callback_params['transactionId']
+    end
+
+    def resolve_user_from_order_number
+      parsed = parse_order_number(callback_params['orderNumber'])
+      return reject_callback('invalid_order_number') if parsed.is_a?(Symbol)
+
+      prefix, user_id = parsed
+      user = User.find_by(id: user_id)
+      return reject_callback('user_not_found') if user.nil?
+
+      email_local = user.email.to_s.partition('@').first
+      return reject_callback('order_number_mismatch') unless email_local == prefix
+
+      user
+    end
+
+    # Returns :invalid_format, :invalid_user_id, or [email_local_prefix, user_id Integer]
+    def parse_order_number(raw)
+      order_number = raw.to_s.strip
+      match = order_number.match(ORDER_NUMBER_PATTERN)
+      return :invalid_format unless match
+
+      prefix = match[1]
+      return :invalid_format if prefix.blank?
+
+      user_id = Integer(match[2], 10)
+      return :invalid_user_id if user_id <= 0
+
+      [prefix, user_id]
+    rescue ArgumentError, TypeError
+      :invalid_user_id
+    end
+
+    def current_application_for(user)
+      Application.active_conference_applications.find_by(user_id: user.id)
+    end
+
+    def payment_attributes(user)
+      {
+        transaction_type: callback_params['transactionType'],
+        transaction_status: callback_params['transactionStatus'],
+        transaction_id: transaction_id,
+        total_amount: callback_params['transactionTotalAmount'],
+        transaction_date: callback_params['transactionDate'],
+        account_type: callback_params['transactionAcountType'],
+        result_code: callback_params['transactionResultCode'],
+        result_message: callback_params['transactionResultMessage'],
+        user_account: callback_params['orderNumber'],
+        payer_identity: user.email,
+        timestamp: callback_params['timestamp'],
+        transaction_hash: callback_params['hash'],
+        user_id: user.id,
+        conf_year: ApplicationSetting.get_current_app_year
+      }
+    end
+
+    def reject_callback(reason)
+      record_callback('rejected', nil, nil, reason)
+      Result.new(status: :forbidden, payment: nil)
+    end
+
+    def record_callback(status, user = nil, payment = nil, reason = nil)
+      PaymentGatewayCallback.create(
+        user: user,
+        payment: payment,
+        transaction_id: transaction_id,
+        processing_status: status,
+        event_type: 'receipt',
+        failure_reason: reason,
+        payload: callback_params
+      )
+    end
+  end
+end

--- a/app/services/payments/gateway_receipt_recorder.rb
+++ b/app/services/payments/gateway_receipt_recorder.rb
@@ -16,18 +16,23 @@ module Payments
       return callback_user if callback_user.is_a?(Result)
 
       if Payment.exists?(transaction_id: transaction_id)
-        record_callback('duplicate', callback_user)
-        return Result.new(status: :duplicate, payment: nil)
+        return duplicate_result(callback_user)
       end
 
       payment = Payment.new(payment_attributes(callback_user))
-      if payment.save
-        current_application_for(callback_user)&.update(offer_status: 'registration_accepted')
-        record_callback('recorded', callback_user, payment)
-        Result.new(status: :recorded, payment: payment)
-      else
-        record_callback('error', callback_user, nil, payment.errors.full_messages.join(', '))
-        Result.new(status: :error, payment: nil)
+      begin
+        if payment.save
+          current_application_for(callback_user)&.update(offer_status: 'registration_accepted')
+          record_callback('recorded', callback_user, payment)
+          Result.new(status: :recorded, payment: payment)
+        elsif duplicate_transaction_id_failure?(payment)
+          duplicate_result(callback_user)
+        else
+          record_callback('error', callback_user, nil, payment.errors.full_messages.join(', '))
+          Result.new(status: :error, payment: nil)
+        end
+      rescue ActiveRecord::RecordNotUnique
+        duplicate_result(callback_user)
       end
     end
 
@@ -96,6 +101,15 @@ module Payments
     def reject_callback(reason)
       record_callback('rejected', nil, nil, reason)
       Result.new(status: :forbidden, payment: nil)
+    end
+
+    def duplicate_result(callback_user)
+      record_callback('duplicate', callback_user)
+      Result.new(status: :duplicate, payment: nil)
+    end
+
+    def duplicate_transaction_id_failure?(payment)
+      payment.errors.of_kind?(:transaction_id, :taken)
     end
 
     def record_callback(status, user = nil, payment = nil, reason = nil)

--- a/db/migrate/20260406114103_create_payment_gateway_callbacks.rb
+++ b/db/migrate/20260406114103_create_payment_gateway_callbacks.rb
@@ -1,0 +1,18 @@
+class CreatePaymentGatewayCallbacks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :payment_gateway_callbacks do |t|
+      t.references :payment, foreign_key: true
+      t.references :user, foreign_key: true
+      t.string :transaction_id
+      t.string :processing_status, null: false
+      t.string :event_type, null: false, default: 'receipt'
+      t.text :failure_reason
+      t.jsonb :payload, null: false, default: {}
+
+      t.timestamps
+    end
+
+    add_index :payment_gateway_callbacks, :transaction_id
+    add_index :payment_gateway_callbacks, :processing_status
+  end
+end

--- a/db/migrate/20260406171925_add_unique_index_on_payments_transaction_id.rb
+++ b/db/migrate/20260406171925_add_unique_index_on_payments_transaction_id.rb
@@ -1,0 +1,9 @@
+# Enforces transaction_id uniqueness at the DB level (concurrent callbacks).
+# If this migration fails, resolve duplicate transaction_id values in payments first.
+class AddUniqueIndexOnPaymentsTransactionId < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :payments, :transaction_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_31_160000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_06_114103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -171,6 +171,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_31_160000) do
     t.boolean "active", default: true
   end
 
+  create_table "payment_gateway_callbacks", force: :cascade do |t|
+    t.bigint "payment_id"
+    t.bigint "user_id"
+    t.string "transaction_id"
+    t.string "processing_status", null: false
+    t.string "event_type", default: "receipt", null: false
+    t.text "failure_reason"
+    t.jsonb "payload", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["payment_id"], name: "index_payment_gateway_callbacks_on_payment_id"
+    t.index ["processing_status"], name: "index_payment_gateway_callbacks_on_processing_status"
+    t.index ["transaction_id"], name: "index_payment_gateway_callbacks_on_transaction_id"
+    t.index ["user_id"], name: "index_payment_gateway_callbacks_on_user_id"
+  end
+
   create_table "payments", force: :cascade do |t|
     t.string "transaction_type"
     t.string "transaction_status"
@@ -222,5 +238,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_31_160000) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "applications", "partner_registrations"
   add_foreign_key "applications", "users"
+  add_foreign_key "payment_gateway_callbacks", "payments"
+  add_foreign_key "payment_gateway_callbacks", "users"
   add_foreign_key "payments", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_06_114103) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_06_171925) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -204,6 +204,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_06_114103) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "conf_year"
+    t.index ["transaction_id"], name: "index_payments_on_transaction_id", unique: true
     t.index ["user_id"], name: "index_payments_on_user_id"
   end
 

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PaymentsController, type: :controller do
         transactionAcountType: 'registration',
         transactionResultCode: '0',
         transactionResultMessage: 'Approved',
-        orderNumber: 'testuser-123',
+        orderNumber: "#{user.email.partition('@').first}-#{user.id}",
         timestamp: Time.current.to_i.to_s,
         hash: 'valid_hash_here'
       }
@@ -136,9 +136,9 @@ RSpec.describe PaymentsController, type: :controller do
     end
 
     context 'when user is not authenticated' do
-      it 'redirects to sign in page' do
+      it 'processes callback without requiring user sign in' do
         post :payment_receipt, params: valid_params
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(all_payments_path)
       end
     end
   end
@@ -333,7 +333,7 @@ RSpec.describe PaymentsController, type: :controller do
             transactionAcountType: 'registration',
             transactionResultCode: '0',
             transactionResultMessage: 'Approved',
-            orderNumber: 'testuser-123'
+            orderNumber: "#{user.email.partition('@').first}-#{user.id}"
           }
           expect(response).not_to have_http_status(:forbidden)
         end
@@ -351,7 +351,7 @@ RSpec.describe PaymentsController, type: :controller do
             transactionAcountType: 'registration',
             transactionResultCode: '0',
             transactionResultMessage: 'Approved',
-            orderNumber: 'testuser-123'
+            orderNumber: "#{user.email.partition('@').first}-#{user.id}"
           }
           expect(response).to have_http_status(:forbidden)
         end
@@ -369,7 +369,7 @@ RSpec.describe PaymentsController, type: :controller do
             transactionAcountType: 'registration',
             transactionResultCode: '0',
             transactionResultMessage: 'Approved',
-            orderNumber: 'testuser-123'
+            orderNumber: "#{user.email.partition('@').first}-#{user.id}"
           }
           expect(response).to have_http_status(:forbidden)
         end
@@ -387,7 +387,25 @@ RSpec.describe PaymentsController, type: :controller do
             transactionAcountType: 'registration',
             transactionResultCode: '0',
             transactionResultMessage: 'Approved',
-            orderNumber: 'testuser-123'
+            orderNumber: "#{user.email.partition('@').first}-#{user.id}"
+          }
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'with missing orderNumber' do
+        it 'returns forbidden status' do
+          post :payment_receipt, params: {
+            hash: 'valid_hash',
+            timestamp: '1234567890',
+            transactionId: 'test_123',
+            transactionType: 'Credit',
+            transactionStatus: '1',
+            transactionTotalAmount: '10000',
+            transactionDate: '202401011200',
+            transactionAcountType: 'registration',
+            transactionResultCode: '0',
+            transactionResultMessage: 'Approved'
           }
           expect(response).to have_http_status(:forbidden)
         end
@@ -472,7 +490,7 @@ RSpec.describe PaymentsController, type: :controller do
           transactionAcountType: 'registration',
           transactionResultCode: '0',
           transactionResultMessage: 'Approved',
-          orderNumber: 'testuser-123',
+          orderNumber: "#{user.email.partition('@').first}-#{user.id}",
           timestamp: Time.current.to_i.to_s,
           hash: 'valid_hash_here'
         }

--- a/spec/factories/payment_gateway_callbacks.rb
+++ b/spec/factories/payment_gateway_callbacks.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :payment_gateway_callback do
+    processing_status { 'recorded' }
+    event_type { 'receipt' }
+    transaction_id { "txn_#{SecureRandom.hex(4)}" }
+    payload do
+      {
+        'transactionId' => transaction_id,
+        'timestamp' => Time.current.to_i.to_s,
+        'hash' => SecureRandom.hex(8),
+        'orderNumber' => "user-#{create(:user).id}"
+      }
+    end
+  end
+end

--- a/spec/models/payment_gateway_callback_spec.rb
+++ b/spec/models/payment_gateway_callback_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PaymentGatewayCallback, type: :model do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      callback = build(:payment_gateway_callback)
+      expect(callback).to be_valid
+    end
+
+    it 'is invalid with unsupported processing_status' do
+      callback = build(:payment_gateway_callback, processing_status: 'unknown_status')
+      expect(callback).not_to be_valid
+      expect(callback.errors[:processing_status]).to include('is not included in the list')
+    end
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Payment, type: :model do
   describe 'class methods' do
     describe '.ransackable_associations' do
       it 'returns the correct associations' do
-        expect(Payment.ransackable_associations).to match_array(["user"])
+        expect(Payment.ransackable_associations).to match_array(%w[user payment_gateway_callbacks])
       end
     end
 

--- a/spec/requests/payments_spec.rb
+++ b/spec/requests/payments_spec.rb
@@ -161,12 +161,11 @@ RSpec.describe "Payments", type: :request do
           "transactionAcountType" => "registration",
           "transactionResultCode" => "0",
           "transactionResultMessage" => "Approved",
-          "orderNumber" => "user-1"
+          "orderNumber" => "#{user.email.partition('@').first}-#{user.id}"
         }
       end
 
       before do
-        sign_in user
         allow_any_instance_of(PaymentsController).to receive(:verify_payment_callback).and_return(true)
 
         mock_application = instance_double(Application)
@@ -183,9 +182,32 @@ RSpec.describe "Payments", type: :request do
         end
 
         it "does not create a new payment and redirects to all_payments_path" do
-          post payment_receipt_path, params: payment_params
+          expect {
+            post payment_receipt_path, params: payment_params
+          }.to change(PaymentGatewayCallback, :count).by(1)
           expect(response).to redirect_to(all_payments_path)
+          expect(PaymentGatewayCallback.order(:id).last.processing_status).to eq('duplicate')
         end
+      end
+
+      context "when callback user cannot be resolved from orderNumber" do
+        it "returns forbidden status" do
+          payment_params["orderNumber"] = "missing-user-999999"
+          expect {
+            post payment_receipt_path, params: payment_params
+          }.to change(PaymentGatewayCallback, :count).by(1)
+          expect(response).to have_http_status(:forbidden)
+          expect(PaymentGatewayCallback.order(:id).last.processing_status).to eq('rejected')
+        end
+      end
+
+      it "creates a payment and records a callback audit row" do
+        expect {
+          post payment_receipt_path, params: payment_params
+        }.to change(Payment, :count).by(1).and change(PaymentGatewayCallback, :count).by(1)
+
+        expect(response).to redirect_to(all_payments_path)
+        expect(PaymentGatewayCallback.order(:id).last.processing_status).to eq('recorded')
       end
     end
   end

--- a/spec/services/payments/gateway_receipt_recorder_spec.rb
+++ b/spec/services/payments/gateway_receipt_recorder_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe Payments::GatewayReceiptRecorder, type: :service do
+  let(:user) { create(:user) }
+  let(:application) { create(:application, user: user) }
+  let(:callback_params) do
+    {
+      'transactionType' => 'Credit',
+      'transactionStatus' => '1',
+      'transactionId' => 'service_txn_123',
+      'transactionTotalAmount' => '10000',
+      'transactionDate' => Time.current.strftime('%m/%d/%Y'),
+      'transactionAcountType' => 'registration',
+      'transactionResultCode' => '0',
+      'transactionResultMessage' => 'Approved',
+      'orderNumber' => "#{user.email.partition('@').first}-#{user.id}",
+      'timestamp' => Time.current.to_i.to_s,
+      'hash' => 'valid_hash'
+    }
+  end
+
+  before do
+    create(:application_setting, active_application: true, contest_year: Time.current.year)
+    allow(ApplicationSetting).to receive(:get_current_app_year).and_return(Time.current.year)
+    application
+  end
+
+  describe '#call' do
+    it 'records a new payment and creates a recorded callback audit' do
+      result = described_class.new(callback_params: callback_params).call
+
+      expect(result.status).to eq(:recorded)
+      expect(Payment.find_by(transaction_id: 'service_txn_123')).to be_present
+
+      callback = PaymentGatewayCallback.order(:id).last
+      expect(callback.processing_status).to eq('recorded')
+      expect(callback.user_id).to eq(user.id)
+      expect(callback.payment_id).to be_present
+      expect(callback.transaction_id).to eq('service_txn_123')
+    end
+
+    it 'returns duplicate and creates duplicate callback audit when transaction already exists' do
+      create(:payment, transaction_id: 'service_txn_123', user: user)
+
+      result = described_class.new(callback_params: callback_params).call
+
+      expect(result.status).to eq(:duplicate)
+      callback = PaymentGatewayCallback.order(:id).last
+      expect(callback.processing_status).to eq('duplicate')
+      expect(callback.user_id).to eq(user.id)
+      expect(callback.payment_id).to be_nil
+    end
+
+    it 'returns forbidden and creates rejected callback audit when user cannot be resolved' do
+      invalid_params = callback_params.merge('orderNumber' => 'missing-user-999999')
+
+      result = described_class.new(callback_params: invalid_params).call
+
+      expect(result.status).to eq(:forbidden)
+      callback = PaymentGatewayCallback.order(:id).last
+      expect(callback.processing_status).to eq('rejected')
+      expect(callback.failure_reason).to eq('user_not_found')
+      expect(callback.user_id).to be_nil
+    end
+
+    it 'returns forbidden when orderNumber does not match "<local>-<id>" format' do
+      invalid_params = callback_params.merge('orderNumber' => 'not-valid')
+
+      result = described_class.new(callback_params: invalid_params).call
+
+      expect(result.status).to eq(:forbidden)
+      expect(PaymentGatewayCallback.order(:id).last.failure_reason).to eq('invalid_order_number')
+    end
+
+    it 'returns forbidden when user id segment is not a positive integer' do
+      invalid_params = callback_params.merge('orderNumber' => "#{user.email.partition('@').first}-0")
+
+      result = described_class.new(callback_params: invalid_params).call
+
+      expect(result.status).to eq(:forbidden)
+      expect(PaymentGatewayCallback.order(:id).last.failure_reason).to eq('invalid_order_number')
+    end
+
+    it 'returns forbidden when email local part does not match orderNumber prefix' do
+      invalid_params = callback_params.merge('orderNumber' => "wrongprefix-#{user.id}")
+
+      result = described_class.new(callback_params: invalid_params).call
+
+      expect(result.status).to eq(:forbidden)
+      callback = PaymentGatewayCallback.order(:id).last
+      expect(callback.failure_reason).to eq('order_number_mismatch')
+      expect(callback.user_id).to be_nil
+    end
+  end
+end

--- a/spec/services/payments/gateway_receipt_recorder_spec.rb
+++ b/spec/services/payments/gateway_receipt_recorder_spec.rb
@@ -51,6 +51,25 @@ RSpec.describe Payments::GatewayReceiptRecorder, type: :service do
       expect(callback.payment_id).to be_nil
     end
 
+    it 'returns duplicate when uniqueness validation fails (stale exists? check)' do
+      create(:payment, transaction_id: 'service_txn_123', user: user)
+      allow(Payment).to receive(:exists?).with(transaction_id: 'service_txn_123').and_return(false)
+
+      result = described_class.new(callback_params: callback_params).call
+
+      expect(result.status).to eq(:duplicate)
+      expect(PaymentGatewayCallback.order(:id).last.processing_status).to eq('duplicate')
+    end
+
+    it 'returns duplicate when insert raises RecordNotUnique (concurrent callbacks)' do
+      allow_any_instance_of(Payment).to receive(:save).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+
+      result = described_class.new(callback_params: callback_params).call
+
+      expect(result.status).to eq(:duplicate)
+      expect(PaymentGatewayCallback.order(:id).last.processing_status).to eq('duplicate')
+    end
+
     it 'returns forbidden and creates rejected callback audit when user cannot be resolved' do
       invalid_params = callback_params.merge('orderNumber' => 'missing-user-999999')
 


### PR DESCRIPTION
This pull request introduces a robust audit trail for payment gateway callbacks, improves the reliability of payment receipt processing, and enhances admin visibility into payment-related events. The changes include a new `PaymentGatewayCallback` model and table, a refactored service object for handling gateway receipts, and updates to the admin interface and tests.

**Payment Gateway Callback Auditing and Processing Improvements:**

* Introduced the `PaymentGatewayCallback` model and database table to log all payment gateway callback attempts, including their status (recorded, duplicate, rejected, error), payload, and associations to users and payments. This provides a transparent audit trail for all gateway interactions. [[1]](diffhunk://#diff-04c51f8f2645b544f8c2da15be9680141b4f4a68245f31b7c659c24a0b91b00fR1-R36) [[2]](diffhunk://#diff-138718cd86779d2d49559c5b1a6813f618691511528e154df89df085297308b2R1-R18) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R174-R189) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R241-R242)
* Refactored payment receipt processing into a new service object (`Payments::GatewayReceiptRecorder`), which handles duplicate detection, user resolution from the `orderNumber`, error handling, and records every callback attempt in the new audit table. [[1]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fL21-R31) [[2]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fL78-R68) [[3]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fR163) [[4]](diffhunk://#diff-6697ef02fabc70d4c6ceec34b6073e3e75ba59d83eb52b9d9a76a2eb5bfb57a9R1-R113)
* The payment receipt endpoint now allows unauthenticated access (for gateway callbacks), improves parameter validation (requires `orderNumber`), and returns appropriate HTTP status codes for error cases. [[1]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fL10-R12) [[2]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fL78-R68)

**Admin and Model Enhancements:**

* Added ActiveAdmin resources for `PaymentGatewayCallback`, including filters and detail views, and integrated a "Gateway callbacks" panel into the payment admin page for visibility into related gateway events. [[1]](diffhunk://#diff-b9da3cb2c355da2244cd16064c9680537544a37e92cbbd805a20fb5d0ec58b95R1-R55) [[2]](diffhunk://#diff-e224949c8c92ef478c1c7361607ca8f199d9d47ea6dc37cfc6c9ac67d4ae1129R78-R97)
* Updated the `Payment` model to establish a `has_many` association with `PaymentGatewayCallback` and made it ransackable for admin filtering. [[1]](diffhunk://#diff-81c4948f81e13d5b8161692b5201740a8c2d9b050576240db5f3df4edfb7d800R29-R35) [[2]](diffhunk://#diff-08377f2abff8a332de84663c74114e5671583e5757a4935197c35f8f109d48baL96-R96)

**Testing and Factories:**

* Updated and expanded controller specs to reflect the new callback processing logic, including tests for all relevant error and success cases, and added a factory and model spec for `PaymentGatewayCallback`. [[1]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL50-R50) [[2]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL139-R141) [[3]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL336-R336) [[4]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL354-R354) [[5]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL372-R372) [[6]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL390-R408) [[7]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL475-R493) [[8]](diffhunk://#diff-50c40501e1b93d2560c74a25c205ee1661e96403bfcfa167605cf41df113c5d2R1-R15) [[9]](diffhunk://#diff-9f60c2be602c8ea8e043dddbb1a05f6025d8f9361cce6dfdb1407888db061234R1-R16)

These changes collectively improve the security, traceability, and maintainability of payment gateway integrations.

**References:**  
[[1]](diffhunk://#diff-04c51f8f2645b544f8c2da15be9680141b4f4a68245f31b7c659c24a0b91b00fR1-R36) [[2]](diffhunk://#diff-138718cd86779d2d49559c5b1a6813f618691511528e154df89df085297308b2R1-R18) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R174-R189) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R241-R242) [[5]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fL21-R31) [[6]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fL78-R68) [[7]](diffhunk://#diff-2367d91b56866521c7aac809fab7d59fc12cdec963c3cb61f832cd0b762fe07fR163) [[8]](diffhunk://#diff-6697ef02fabc70d4c6ceec34b6073e3e75ba59d83eb52b9d9a76a2eb5bfb57a9R1-R113) [[9]](diffhunk://#diff-b9da3cb2c355da2244cd16064c9680537544a37e92cbbd805a20fb5d0ec58b95R1-R55) [[10]](diffhunk://#diff-e224949c8c92ef478c1c7361607ca8f199d9d47ea6dc37cfc6c9ac67d4ae1129R78-R97) [[11]](diffhunk://#diff-81c4948f81e13d5b8161692b5201740a8c2d9b050576240db5f3df4edfb7d800R29-R35) [[12]](diffhunk://#diff-08377f2abff8a332de84663c74114e5671583e5757a4935197c35f8f109d48baL96-R96) [[13]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL50-R50) [[14]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL139-R141) [[15]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL336-R336) [[16]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL354-R354) [[17]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL372-R372) [[18]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL390-R408) [[19]](diffhunk://#diff-f1d1e018ebc4a31cfdeb2eaa67601a103753186b79e1a0e86c79e6185975fe9bL475-R493) [[20]](diffhunk://#diff-50c40501e1b93d2560c74a25c205ee1661e96403bfcfa167605cf41df113c5d2R1-R15) [[21]](diffhunk://#diff-9f60c2be602c8ea8e043dddbb1a05f6025d8f9361cce6dfdb1407888db061234R1-R16)